### PR TITLE
Move `autocomplete` and `searchHints` to `SearchBar`

### DIFF
--- a/client/src/components/SearchBar.js
+++ b/client/src/components/SearchBar.js
@@ -1,15 +1,37 @@
-import { useContext, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
+import $ from 'jquery';
+
 import DataContext from '../context';
+import addCourse from '../timetable/addCourse';
 
 import styles from './SearchBar.module.css';
 
 const SearchBar = () => {
     const data = useContext(DataContext);
+    const inputRef = useRef(null);
     const [inputValue, setInputValue] = useState('');
 
     const handleSubmit = (event) => {
         event.preventDefault();
-    }
+    };
+
+    useEffect(() => {
+        const inputEl = inputRef.current;
+        $(inputEl).autocomplete({
+            // source: "http://coust.442.hk/json/parser.php?type=searchHints",
+            source: window.searchHints,
+            minLength: 0,
+            focus: (event, ui) => {
+                event.preventDefault();
+            },
+            select: (event, ui) => {
+                event.preventDefault();
+                const courseCode = ui.item.value.split(': ')[0];
+                addCourse(data, courseCode);
+                setInputValue('');
+            },
+        });
+    }, [data]);
 
     return (
         <form
@@ -21,6 +43,7 @@ const SearchBar = () => {
             </div>
             <div className={styles.inputContainer}>
                 <input
+                    ref={inputRef}
                     className={styles.input}
                     id="add"
                     type="text"

--- a/client/src/components/SearchBar.js
+++ b/client/src/components/SearchBar.js
@@ -1,4 +1,11 @@
-import { useContext, useEffect, useRef, useState } from 'react';
+import {
+    useContext,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
+import { useSelector } from 'react-redux';
 import $ from 'jquery';
 
 import DataContext from '../context';
@@ -8,8 +15,29 @@ import styles from './SearchBar.module.css';
 
 const SearchBar = () => {
     const data = useContext(DataContext);
+    const timetable = useSelector(state => (state.app.timetable));
     const inputRef = useRef(null);
     const [inputValue, setInputValue] = useState('');
+
+    const searchHints = useMemo(() => {
+        if (!data) {
+            return [];
+        }
+
+        const ret = [];
+        Object.entries(data).forEach(([courseCode, value]) => {
+            if (courseCode === 'terms' || courseCode === 'lastUpdated') {
+                return;
+            }
+            if (timetable.hasOwnProperty(courseCode)){
+                return;
+            }
+            ret.push(`${courseCode}: ${value.name}`);
+        });
+        ret.sort();
+
+        return ret;
+    }, [data, timetable]);
 
     const handleSubmit = (event) => {
         event.preventDefault();
@@ -18,8 +46,7 @@ const SearchBar = () => {
     useEffect(() => {
         const inputEl = inputRef.current;
         $(inputEl).autocomplete({
-            // source: "http://coust.442.hk/json/parser.php?type=searchHints",
-            source: window.searchHints,
+            source: searchHints,
             minLength: 0,
             focus: (event, ui) => {
                 event.preventDefault();
@@ -31,7 +58,7 @@ const SearchBar = () => {
                 setInputValue('');
             },
         });
-    }, [data]);
+    }, [data, searchHints]);
 
     return (
         <form

--- a/client/src/timetable.js
+++ b/client/src/timetable.js
@@ -17,7 +17,6 @@ import './color.css';
 import './override-jquery-ui.css';
 
 import compactTable from './timetable/compactTable';
-import getURL from './timetable/getURL';
 import loadFromUrlOrStorage from './timetable/loadFromUrlOrStorage';
 
 window.jQuery = $;
@@ -33,8 +32,6 @@ window.CLIENT_PATH = 'https://coust.github.io/';
 window.COOKIE_EXPIRE_DAYS = 50;
 
 function oldTimetableScript(data) {
-    getURL(data);
-
     // load courses added from cookies
     loadFromUrlOrStorage(data);
     compactTable();

--- a/client/src/timetable.js
+++ b/client/src/timetable.js
@@ -27,17 +27,12 @@ require('jquery-ui-touch-punch');
 window.readMode = false;
 window.color = 0;
 window.courseColor = [];
-window.searchHints = [];
 
 window.API_PATH = 'https://coust.442.hk/';
 window.CLIENT_PATH = 'https://coust.github.io/';
 window.COOKIE_EXPIRE_DAYS = 50;
 
 function oldTimetableScript(data) {
-    $.each(data, function (key, val) {
-        if (key === "terms" || key === "lastUpdated") return true;
-        window.searchHints.push(key + ': ' + val["name"]);
-    });
     getURL(data);
 
     // load courses added from cookies

--- a/client/src/timetable.js
+++ b/client/src/timetable.js
@@ -16,7 +16,6 @@ import 'jquery-ui/themes/base/menu.css';
 import './color.css';
 import './override-jquery-ui.css';
 
-import addCourse from './timetable/addCourse';
 import compactTable from './timetable/compactTable';
 import getURL from './timetable/getURL';
 import loadFromUrlOrStorage from './timetable/loadFromUrlOrStorage';
@@ -41,25 +40,6 @@ function oldTimetableScript(data) {
     });
     getURL(data);
 
-    $("#add").autocomplete({
-        // source: "http://coust.442.hk/json/parser.php?type=searchHints",
-        source: window.searchHints,
-        minLength: 0,
-        focus: function (event, ui) {
-            event.preventDefault();
-        },
-        select: (event, ui) => {
-            event.preventDefault();
-
-            const courseCode = ui.item.value.split(': ')[0];
-            addCourse(data, courseCode);
-        },
-    }).focus(function () {
-        $(this).autocomplete("search", "");
-    });
-    $("#add").click(function () {
-        $(this).autocomplete("search", $(this).val());
-    });
     // load courses added from cookies
     loadFromUrlOrStorage(data);
     compactTable();

--- a/client/src/timetable/addCourse.js
+++ b/client/src/timetable/addCourse.js
@@ -75,7 +75,6 @@ export default function addCourse(data, courseCode, registeredSections) {
 
     window.courseColor[courseCode] = window.color;
     window.color = (window.color + 1) % 10;
-    $('#add').val(''); // clear input text
 
     return false; // always return false to avoid form submitting
 }

--- a/client/src/timetable/addCourse.js
+++ b/client/src/timetable/addCourse.js
@@ -32,17 +32,6 @@ export default function addCourse(data, courseCode, registeredSections) {
 
     const course = data[courseCode];
 
-    // remove the added course from search hints of autocomplete
-    const hintsText = `${courseCode}: ${course.name}`;
-    for (let i = 0; i < window.searchHints.length;) {
-        if (window.searchHints[i] === hintsText) {
-            window.searchHints.splice(i, 1);
-            break;
-        } else {
-            i++;
-        }
-    }
-
     const sections = getSections(data, courseCode);
     if (registeredSections) {
         registeredSections.forEach(section => {

--- a/client/src/timetable/addCourseBox.js
+++ b/client/src/timetable/addCourseBox.js
@@ -2,7 +2,6 @@ import $ from 'jquery';
 
 import addSection from './addSection';
 import addVirtualCourse from './addVirtualCourse';
-import getURL from './getURL';
 import removeSection from './removeSection';
 import removeVirtualCourse from './removeVirtualCourse';
 import saveTimetableToStorage from './saveTimetableToStorage';
@@ -173,7 +172,6 @@ export default function addCourseBox(data, code, section, weekday, start, end, s
     $("div.lesson." + code).parentsUntil("tr").parent().removeClass("spare-tr");
     // save timetable to cookies
     saveTimetableToStorage(data);
-    getURL(data);
     updateConflictStyle();
     if (window.readMode) $(".lesson.draggable").draggable("disable");
 }

--- a/client/src/timetable/addSection.js
+++ b/client/src/timetable/addSection.js
@@ -1,8 +1,5 @@
-import $ from 'jquery';
-
 import addCourseBox from './addCourseBox';
 import getSectionObjs from './getSectionObjs';
-import getURL from './getURL';
 import saveTimetableToStorage from './saveTimetableToStorage';
 
 // TODO: Redux flow should be put back into React components
@@ -33,7 +30,6 @@ export default function addSection(data, course, section, singleton, virtual) {
         if (datetime[0] === "TBA") { // TBA cannot be added into timetable
             // save timetable to cookies
             saveTimetableToStorage(data);
-            getURL(data);
             continue;
         }
         weekdays = datetime[hasDate].match(/(Mo|Tu|We|Th|Fr|Sa|Su)/ig);

--- a/client/src/timetable/removeCourse.js
+++ b/client/src/timetable/removeCourse.js
@@ -27,10 +27,6 @@ export default function removeCourse(data,courseCode) {
         $(this).remove();
     });
 
-    // add back to search hints of autocomplete
-    window.searchHints.push(`${courseCode}: ${data[courseCode].name}`);
-    window.searchHints.sort();
-
     // TODO: Redux flow should be put back into React components
     store.dispatch(getRemoveCourseAction(courseCode));
 

--- a/client/src/timetable/removeSection.js
+++ b/client/src/timetable/removeSection.js
@@ -4,7 +4,6 @@ import { getRemoveCourseSectionAction } from '../actions/course';
 import store from '../store';
 
 import compactTable from './compactTable';
-import getURL from './getURL';
 
 export default function removeSection(data, code, section) {
     // TODO: Redux flow should be put back into React components
@@ -23,5 +22,4 @@ export default function removeSection(data, code, section) {
         $(this).remove();
     });
     compactTable();
-    getURL(data);
 }


### PR DESCRIPTION
- Replace all `window.searchHints` usages by computing `searchHints` in `SearchBar` with `useMemo`
- Apply jQuery autocomplete in `SearchBar` instead of the old timetable script
- Remove unnecessary `getURL` calls